### PR TITLE
Add vender/device ID of TP-Link 8822B USB products

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ CONFIG_RTW88_USB=m
 CONFIG_RTW88_8822B=y
 CONFIG_RTW88_8822C=y
 ccflags-y += -DDEBUG
-ccflags-y += -DCONFIG_RTW88_DEBUG=y
-ccflags-y += -DCONFIG_RTW88_DEBUGFS=y
+ccflags-y += -DCONFIG_RTW88_DEBUG
+ccflags-y += -DCONFIG_RTW88_DEBUGFS
 ifeq ($(CONFIG_RTW88_8822B), y)
 ccflags-y += -DCONFIG_RTW88_8822B
 endif

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Load driver at boot:
 $ sudo mkdir -p /lib/firmware/rtw88
 $ sudo cp fw/rtw8822* /lib/firmware/rtw88/
 $ sudo mkdir /lib/modules/`uname -r`/kernel/drivers/net/wireless/realtek/rtw88
-$ sudo cp rtw88.ko /lib/modules/`uname -r`/kernel/drivers/net/wireless/
-$ sudo cp rtwusb.ko /lib/modules/`uname -r`/kernel/drivers/net/wireless/
+$ sudo cp rtw88.ko /lib/modules/`uname -r`/kernel/drivers/net/wireless/realtek/rtw88
+$ sudo cp rtwusb.ko /lib/modules/`uname -r`/kernel/drivers/net/wireless/realtek/rtw88
 $ sudo depmod -a
 $ sudo echo -e "rtw88\nrtwusb" > /etc/modules-load.d/rtwusb.conf
 $ sudo systemctl start systemd-modules-load
@@ -38,3 +38,5 @@ Connect to the AP without security:
 ```console
 $ sudo iw wlanX connect <AP name>
 ```
+## Known Issues
+* This driver doesn't support pcie. That means, loading this module will cause unpredictable results to other working Realtek wifi pcie device, especially to those laptops with Realtek wifi IC running kernel > v5.2.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This driver is forked from [neojou/rtw88-usb](https://github.com/neojou/rtw88-us
 
 The driver supports Realtek USB wifi IC 88x2bu and 88x2cu, and supports at least managed (i.e. client) and monitor mode.
 
-For a backport version (backport to kernel v4.15), please check [this branch](https://github.com/borting/rtw88-usb/blob/backport-cfc1291-v4.15.0/README.md).
+For a backport version (backport to kernel v4.15), please check [this branch](https://github.com/borting/rtw88-usb/tree/backport-cfc1291-v4.15.0).
 
 ## Build
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The driver supports Realtek USB wifi IC 88x2bu and 88x2cu, and supports at least
 $ make clean
 $ make
 ```
-## Install
+## Installation
 Load driver for test:
 ```console
 $ sudo mkdir -p /lib/firmware/rtw88
@@ -25,6 +25,9 @@ $ sudo cp fw/rtw8822* /lib/firmware/rtw88/
 $ sudo mkdir /lib/modules/`uname -r`/kernel/drivers/net/wireless/realtek/rtw88
 $ sudo cp rtw88.ko /lib/modules/`uname -r`/kernel/drivers/net/wireless/
 $ sudo cp rtwusb.ko /lib/modules/`uname -r`/kernel/drivers/net/wireless/
+$ sudo depmod -a
+$ sudo echo -e "rtw88\nrtwusb" > /etc/modules-load.d/rtwusb.conf
+$ sudo systemctl start systemd-modules-load
 ```
 ## General Commands
 Scan:

--- a/README.md
+++ b/README.md
@@ -4,13 +4,17 @@ This driver is forked from [neojou/rtw88-usb](https://github.com/neojou/rtw88-us
 
 The driver supports Realtek USB wifi IC 88x2bu and 88x2cu, and supports at least managed (i.e. client) and monitor mode.
 
+For a backport version (backport to kernel v4.15), please check [this branch](https://github.com/borting/rtw88-usb/blob/backport-cfc1291-v4.15.0/README.md).
+
 ## Build
 
 ```console
 $ make clean
 $ make
 ```
+
 ## Installation
+
 Load driver for test:
 ```console
 $ sudo mkdir -p /lib/firmware/rtw88
@@ -29,7 +33,9 @@ $ sudo depmod -a
 $ sudo echo -e "rtw88\nrtwusb" > /etc/modules-load.d/rtwusb.conf
 $ sudo systemctl start systemd-modules-load
 ```
+
 ## General Commands
+
 Scan:
 ```console
 $ sudo iw wlanX scan
@@ -39,4 +45,5 @@ Connect to the AP without security:
 $ sudo iw wlanX connect <AP name>
 ```
 ## Known Issues
+
 * This driver doesn't support pcie. That means, loading this module will cause unpredictable results to other working Realtek wifi pcie device, especially to those laptops with Realtek wifi IC running kernel > v5.2.

--- a/README.md
+++ b/README.md
@@ -1,26 +1,37 @@
 # rtw88-usb
 
-This is based on 
-https://github.com/torvalds/linux/tree/master/drivers/net/wireless/realtek/rtw88
+This driver is forked from [neojou/rtw88-usb](https://github.com/neojou/rtw88-usb), which is based on Realtek's [rtw88 driver](https://github.com/torvalds/linux/tree/master/drivers/net/wireless/realtek/rtw88) in Linux main trunk.
 
-to add support for USB wifi IC - 88x2bu / 88x2cu
+The driver supports Realtek USB wifi IC 88x2bu and 88x2cu, and supports at least managed (i.e. client) and monitor mode.
 
-fw/rtw8822b_fw.bin can be put under /lib/firmware/rtw88/rtw8822b_fw.bin
+## Build
 
-load driver:
-    sudo insmod rtw88.ko
-    sudo insmod rtwusb.ko
-
+```console
+$ make clean
+$ make
+```
+## Install
+Load driver for test:
+```console
+$ sudo mkdir -p /lib/firmware/rtw88
+$ sudo cp fw/rtw8822* /lib/firmware/rtw88/
+$ sudo insmod rtw88.ko
+$ sudo insmod rtwusb.ko
+```
+Load driver at boot:
+```console
+$ sudo mkdir -p /lib/firmware/rtw88
+$ sudo cp fw/rtw8822* /lib/firmware/rtw88/
+$ sudo mkdir /lib/modules/`uname -r`/kernel/drivers/net/wireless/realtek/rtw88
+$ sudo cp rtw88.ko /lib/modules/`uname -r`/kernel/drivers/net/wireless/
+$ sudo cp rtwusb.ko /lib/modules/`uname -r`/kernel/drivers/net/wireless/
+```
+## General Commands
 Scan:
-    sudo iw wlanX scan
-
+```console
+$ sudo iw wlanX scan
+```
 Connect to the AP without security:
-    sudo iw wlanX connect <AP name>
-
-dynamic IP:
-    can see IP address obtained by DHCP by using ifconfig
-
-loopback test:
-    cat /sys/kernel/debug/rtw88/usb_loopback_func
-    pktsize: 2000, spend: 54 us, throughput=296Mbps
-
+```console
+$ sudo iw wlanX connect <AP name>
+```

--- a/debug.c
+++ b/debug.c
@@ -14,6 +14,7 @@
 #include "phy.h"
 #include "mac.h"
 
+#ifdef CONFIG_RTW88_DEBUGFS
 struct rtw_debugfs_priv {
 	struct rtw_dev *rtwdev;
 
@@ -222,6 +223,7 @@ void rtw_debugfs_deinit(struct rtw_dev *rtwdev)
 {
 	debugfs_remove_recursive(rtwdev->debugfs);
 }
+#endif /* CONFIG_RTW88_DEBUGFS */
 
 #ifdef CONFIG_RTW88_DEBUG
 

--- a/usb.c
+++ b/usb.c
@@ -1582,6 +1582,8 @@ static const struct usb_device_id rtw_usb_id_table[] = {
 	{ RTK_USB_DEVICE(0x0b05, 0x1841, rtw8822b_hw_spec) },	/* ASUS AC55 B1 */
 	{ RTK_USB_DEVICE(0x2001, 0x331c, rtw8822b_hw_spec) },	/* D-Link DWA-182 rev D1 */
 	{ RTK_USB_DEVICE(0x13b1, 0x0043, rtw8822b_hw_spec) },	/* Linksys WUSB6400M */
+	{ RTK_USB_DEVICE(0x2357, 0x0115, rtw8822b_hw_spec) },	/* TP-LINK - T4Uv3 */
+	{ RTK_USB_DEVICE(0x2357, 0x012d, rtw8822b_hw_spec) },	/* TP-LINK - T3U */
 #endif
 #ifdef CONFIG_RTW88_8822C
 	{ RTK_USB_DEVICE_AND_INTERFACE(RTW_USB_VENDOR_ID_REALTEK,


### PR DESCRIPTION
Add TP-Link USB products, Archer T3U & Archer T4U v3, to 8822B's
USB ID table.