### PR TITLE
rtw88-usb: lock free for usb read/write

### DIFF
--- a/usb.h
+++ b/usb.h
@@ -107,13 +107,6 @@ struct rtw_usb {
 	struct rtw_dev *rtwdev;
 	struct usb_device *udev;
 
-	struct mutex usb_buf_mutex; /* mutex for usb_buf */
-	union {
-		__le32 val32;
-		__le16 val16;
-		u8 val8;
-	} usb_buf;
-
 	u8 num_in_pipes;
 	u8 num_out_pipes;
 	unsigned int pipe_interrupt;


### PR DESCRIPTION
This is for the issue #23.

Change to use lock-free programming for usb read/write functions
in usb.c, to prevent atomic operations when scheduling in the
multi-threads parallel system. Though there is some additional
overhead at memory allocation for each usb read/write operations,
mutex lock operations and relative data structures can be taken off.

Signed-off-by: neo_jou <neo_jou@realtek.com>